### PR TITLE
Replacing the double \\ with \\\\

### DIFF
--- a/mathview-lib/src/main/java/com/nishant/math/MathView.java
+++ b/mathview-lib/src/main/java/com/nishant/math/MathView.java
@@ -61,7 +61,8 @@ public final class MathView extends WebView {
       @Override
       public void onPageFinished(WebView view, String url) {
         pageLoaded = true;
-        loadUrl("javascript:showFormula('" + MathView.this.text  + "')");
+        
+        loadUrl("javascript:showFormula('" + MathView.this.text.replace("\\","\\\\")+ "')");
         super.onPageFinished(view, url);
       }
     });
@@ -70,7 +71,7 @@ public final class MathView extends WebView {
   public void setText(String text) {
     this.text = text;
     if (pageLoaded) {
-      loadUrl("javascript:showFormula('" + MathView.this.text  + "')");
+      loadUrl("javascript:showFormula('" + MathView.this.text.replace("\\","\\\\")+ "')");
     } else {
       Log.e(TAG, "Page is not loaded yet.");
     }


### PR DESCRIPTION
After using mathjax library in a webview I found out that when java sends the string of equation(for eg. $$\\dfrac{x^2}{xy}$$) to javascript method instead of sending single back-slash($$\dfrac{x^2}{xy}$$") it sends no slash as a result it doesn't works but when the "\\" is replaced with "\\\\" before sending, a single back-slash is send and it works

I hope you will review the request